### PR TITLE
feat: the paths https://xr.ma and https://xr.ma/0 should now display the same fate contents

### DIFF
--- a/app/0/page.js
+++ b/app/0/page.js
@@ -13,7 +13,7 @@ function Spacer() {
     )
 }
 
-export default function Home() {
+export default function Fate() {
     useEffect(() => {
         console.log("It works?..");
 

--- a/app/page.js
+++ b/app/page.js
@@ -1,13 +1,10 @@
 'use client'
 
-import Link from "next/link";
-import './css.css'
+// Currently displays the same contents as the page at /0
+import Fate from "@/app/0/page";
 
 export default function Home() {
   return (
-      <div className={'lowercase'}>
-        <h1>Home Page</h1>
-        <Link href={"/0"}>Go to Fate</Link>
-      </div>
+      <Fate/>
   );
 }


### PR DESCRIPTION
Modified the pages responsible for displaying the paths at https://xr.ma/0 and https://xr.ma to re-use the same React component in order to display the same contents on both pages. This should ensure there's no need to include `vercel.json` rewrite, possibly an implementation from commits [b864d8806](https://github.com/Wizard254/xrma/commit/b864d88062bafa67635ff2be88406ae2fa694473) and [25460e9b](https://github.com/Wizard254/xrma/commit/25460e9be76d178fe6550372117c0a9e0d2bf9a5)

